### PR TITLE
chore: pass php to >=7.2| >=8.0 , symfony/cache to ^3.4|^4.0|^5.0|^6.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2| >=8.0",
         "composer/ca-bundle": "^1.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "league/url": "^3.3",
         "nesbot/carbon": "^2.41",
-        "symfony/cache": "^3.4|^4.0|^5.0",
+        "symfony/cache": "^3.4|^4.0|^5.0|^6.0",
         "web-token/jwt-checker": "^2.2",
         "web-token/jwt-signature": "^2.2",
         "web-token/jwt-signature-algorithm-ecdsa": "^2.2"
@@ -44,6 +44,6 @@
         "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "^2.9",
         "phpunit/phpunit": "^8.5",
-        "spatie/phpunit-snapshot-assertions": "3.0"
+        "spatie/phpunit-snapshot-assertions": "4.2.15"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,6 @@
         "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "^2.9",
         "phpunit/phpunit": "^8.5",
-        "spatie/phpunit-snapshot-assertions": "4.2.15"
+        "spatie/phpunit-snapshot-assertions": "3.0|4.2.15"
     }
 }


### PR DESCRIPTION
…0 and spatie/phpunit-snapshot-assertions to 4.2.15