### PR TITLE
IAT: Support both nano & micro second format

### DIFF
--- a/src/HeaderChecker/PayconiqIssuedAtChecker.php
+++ b/src/HeaderChecker/PayconiqIssuedAtChecker.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Optios\Payconiq\HeaderChecker;
 

--- a/src/HeaderChecker/PayconiqIssuedAtChecker.php
+++ b/src/HeaderChecker/PayconiqIssuedAtChecker.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Optios\Payconiq\HeaderChecker;
 
@@ -25,10 +25,17 @@ final class PayconiqIssuedAtChecker implements HeaderChecker
         try {
             // Payconiq unexpectedly changed their format on 2023-08-23 to include nanoseconds,
             // Since PHP doesn't support nanoseconds, we're "hacking" it by trimming it to microseconds
-            $pos     = strpos($value, '.');
-            $trimmed = substr($value, 0, $pos + 7) . substr($value, $pos + 10);
 
-            $iat = Carbon::createFromFormat(self::IAT_FORMAT, $trimmed);
+            // It seems that on 2023-08-28 Payconiq changed it back to microsecond format, but ince we can't trust
+            // their api, the regex determines if it's nanosecond or microsecond format and trims when needed
+            if (preg_match('/(?:\.)(\d{9})(?:Z|\+|-)/', $value)) { // format with nano seconds
+                $pos = strpos($value, '.');
+                $trimmed = substr($value, 0, $pos + 7) . substr($value, $pos + 10);
+
+                $iat = Carbon::createFromFormat(self::IAT_FORMAT, $trimmed);
+            } else {
+                $iat = new Carbon($value);
+            }
         } catch (\Exception $e) {
             throw new InvalidHeaderException(
                 sprintf('"%s" has an invalid date format', self::HEADER_NAME),

--- a/src/HeaderChecker/PayconiqIssuedAtChecker.php
+++ b/src/HeaderChecker/PayconiqIssuedAtChecker.php
@@ -26,9 +26,10 @@ final class PayconiqIssuedAtChecker implements HeaderChecker
             // Payconiq unexpectedly changed their format on 2023-08-23 to include nanoseconds,
             // Since PHP doesn't support nanoseconds, we're "hacking" it by trimming it to microseconds
 
-            // It seems that on 2023-08-28 Payconiq changed it back to microsecond format, but ince we can't trust
+            // It seems that on 2023-08-28 Payconiq changed it back to microsecond format, but since we can't trust
             // their api, the regex determines if it's nanosecond or microsecond format and trims when needed
-            if (preg_match('/(?:\.)(\d{9})(?:Z|\+|-)/', $value)) { // format with nano seconds
+
+            if (preg_match('/(?:\.)(\d{9})(?:Z|\+|-)/', $value)) { // format with nanoseconds
                 $pos = strpos($value, '.');
                 $trimmed = substr($value, 0, $pos + 7) . substr($value, $pos + 10);
 

--- a/tests/HeaderChecker/PayconiqIssuedAtCheckerTest.php
+++ b/tests/HeaderChecker/PayconiqIssuedAtCheckerTest.php
@@ -20,21 +20,34 @@ class PayconiqIssuedAtCheckerTest extends TestCase
 
     public function testCheckHeader()
     {
-        $this->checker->checkHeader('2023-08-25T08:28:21.675129286Z');
-        $this->expectException(InvalidHeaderException::class);
-        $this->expectExceptionMessage('"https://payconiq.com/iat" has an invalid date format');
-        $this->checker->checkHeader('Invalid date');
+        $this->checker->checkHeader('2023-08-25T08:28:21.675129Z');
     }
 
-    public function testCheckHeaderOtherTimeZone()
+    public function testCheckHeaderNanoSeconds()
+    {
+        $this->checker->checkHeader('2023-08-25T08:28:21.675129286Z');
+    }
+
+    public function testCheckHeaderNanoSecondsOtherTimeZone()
     {
         $this->checker->checkHeader('2023-08-25T08:28:21.675129286+02:00');
+    }
+
+    public function testCheckHeaderException()
+    {
         $this->expectException(InvalidHeaderException::class);
         $this->expectExceptionMessage('"https://payconiq.com/iat" has an invalid date format');
         $this->checker->checkHeader('Invalid date');
     }
 
     public function testCheckHeaderWhenInFuture()
+    {
+        $this->expectException(InvalidHeaderException::class);
+        $this->expectExceptionMessage('The JWT is issued in the future.');
+        $this->checker->checkHeader(Carbon::tomorrow()->format(PayconiqIssuedAtChecker::IAT_FORMAT));
+    }
+
+    public function testCheckHeaderWhenInFutureOtherFormat()
     {
         $this->expectException(InvalidHeaderException::class);
         $this->expectExceptionMessage('The JWT is issued in the future.');


### PR DESCRIPTION
It seems that on 2023-08-28 Payconiq changed it back to microsecond format, but since we can't trust their api, the regex determines if it's nanosecond or microsecond format and trims when needed