### PR TITLE
Change switchover time

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer require optiosteam/payconiq-client-php
 ```
 
 ## Migrating from 1.x to 2.x: Migration Payconiq > WERO/Bancontact
-On `2025-09-21 03:00:00 CET` the endpoints will be updated automatically to use the new endpoints according to https://docs.payconiq.be/guides/general/preprod072025v4
+On `2025-09-21 05:50:00 CET` the endpoints will be updated automatically to use the new endpoints according to https://docs.payconiq.be/guides/general/preprod072025v4
 
 The code has been updated for PHP 8 (constructor property promotion, enums, immutable with `readonly`, ...)
 

--- a/src/MigrationHelper.php
+++ b/src/MigrationHelper.php
@@ -14,7 +14,7 @@ class MigrationHelper
      *  > Any update before or after this deadline will result in your integration stopping.
      */
 
-    public const SWITCH_DATETIME = '2025-09-21 03:00:00'; // switch to new endpoints at 3AM CET (1 hour buffer)
+    public const SWITCH_DATETIME = '2025-09-21 05:50:00';
     public const TIMEZONE = 'Europe/Brussels'; // CET
 
     public static function switchToNewEndpoints(): bool

--- a/tests/MigrationHelperTest.php
+++ b/tests/MigrationHelperTest.php
@@ -28,10 +28,10 @@ final class MigrationHelperTest extends TestCase
     {
         // SWITCH_DATETIME = '2025-09-21 03:00:00' in Europe/Brussels
         yield 'day before' => ['2025-09-20 12:00:00', false];
-        yield 'one second before' => ['2025-09-21 02:59:59', false];
-        yield 'exact switch time' => ['2025-09-21 03:00:00', true];
-        yield 'one second after' => ['2025-09-21 03:00:01', true];
+        yield 'one second before' => ['2025-09-21 05:49:59', false];
+        yield 'exact switch time' => ['2025-09-21 05:50:00', true];
+        yield 'one second after' => ['2025-09-21 05:50:01', true];
         yield 'day after' => ['2025-09-22 12:00:00', true];
-        yield 'month after' => ['2025-10-21 03:00:00', true];
+        yield 'month after' => ['2025-10-21 05:50:00', true];
     }
 }


### PR DESCRIPTION
This is the information I received from the Payconiq dev support:

> Migration will take place on 21/09 between 02:00CEST and 06:00CEST
> - If endpoint migration happens prior to that time slot, API calls will fail, as the new endpoints will not be available yet.
> - If endpoint migration happens after that time slot, API calls will fail, as the old endpoints will cease to be available.

> In between both, API behavior will depend on migration queue: all requests are executed on a queue, so between 02:00CEST and 06:00CEST one or the other **may** work.

> Merchants are informed once they are mgirated (new endpoint availability starting 02:00CEST) via an automatic mailing system.

Before this above info, I was under the assumption that between 2 & 6AM, both endpoints would work, which doesn't seem to be the case.

People will get migrated between 2 & 6AM, without knowing exactly when this will be (through the queue). But once migrated, you will receive an email. Of course this library can't check your personal email so the automatic switchover is not evident.

For this library we will publish a new tag (2.0.1) that switches everyone over to the new endpoints at 05:50AM. This will be mainly for the people that don't want to stay up and wait for the email that they've been migrated.

A day before the migration, I will publish a new tag (2.1.1) without the switchover logic, and only the new endpoints.
So that people that get migrated before 05:50, have the option to already switch to the new endpoints earlier using this 2.1.1 tag.