### PR TITLE
Update migration date for switchover

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ composer require optiosteam/payconiq-client-php
 ```
 
 ## Migrating from 1.x to 2.x: Migration Payconiq > WERO/Bancontact
-On `2025-09-21 05:50:00 CET` the endpoints will be updated automatically to use the new endpoints according to https://docs.payconiq.be/guides/general/preprod072025v4
+On `2025-10-19 05:50:00 CET` the endpoints will be switched automatically to use the new ones according to https://docs.payconiq.be/guides/general/preprod072025v4
+
+If you have been migrated before 05:50:00 CET, you will be able to use the upcoming 2.1.0 release that only includes the new endpoints.
 
 The code has been updated for PHP 8 (constructor property promotion, enums, immutable with `readonly`, ...)
 

--- a/src/MigrationHelper.php
+++ b/src/MigrationHelper.php
@@ -9,12 +9,13 @@ use Carbon\CarbonImmutable;
 class MigrationHelper
 {
     /**
-     * From https://docs.payconiq.be:
-     *  > Your endpoints will have to be adapted on 21/09/2025 between 02:00 CET and 06:00 CET.
-     *  > Any update before or after this deadline will result in your integration stopping.
+     * > Belangrijk: eerder gaven we aan dat deze aanpassing op 21/09/2025 moet uitgevoerd worden.
+     * > Om u en ons de nodige ruimte te geven voor extra testen en om zeker te zijn dat alles vlekkeloos verloopt,
+     * > verplaatsen we de datum. De nieuwe beoogde datum waarop u de aanpassing moet uitvoeren
+     * > is 19/10/2025, tussen 02:00 en 06:00 uur 's ochtends.
      */
 
-    public const SWITCH_DATETIME = '2025-09-21 05:50:00';
+    public const SWITCH_DATETIME = '2025-10-19 05:50:00';
     public const TIMEZONE = 'Europe/Brussels'; // CET
 
     public static function switchToNewEndpoints(): bool


### PR DESCRIPTION
> Belangrijk: eerder gaven we aan dat deze aanpassing op 21/09/2025 moet uitgevoerd worden . Om u en ons de nodige ruimte te geven voor extra testen en om zeker te zijn dat alles vlekkeloos verloopt, verplaatsen we de datum. De nieuwe beoogde datum waarop u de aanpassing moet uitvoeren is is 19/10/2025.


<img width="614" height="871" alt="Image" src="https://github.com/user-attachments/assets/726731bf-4939-49a4-8ff6-5340b411e42c" />
